### PR TITLE
Refactor redraw cycle and support pre-fetched data

### DIFF
--- a/src/minimap.js
+++ b/src/minimap.js
@@ -63,6 +63,9 @@ const Minimap = ({
     const updatedAspect = aspectProp || defaults.aspect
     const updatedTranslate = translateProp || defaults.translate
 
+    console.log('scale', updatedScale)
+    console.log('translate', updatedTranslate)
+
     updatedProjection.scale(updatedScale * (WIDTH / (2 * Math.PI)))
     updatedProjection.translate([
       ((1 + updatedTranslate[0]) * WIDTH) / 2,

--- a/src/minimap.js
+++ b/src/minimap.js
@@ -63,9 +63,6 @@ const Minimap = ({
     const updatedAspect = aspectProp || defaults.aspect
     const updatedTranslate = translateProp || defaults.translate
 
-    console.log('scale', updatedScale)
-    console.log('translate', updatedTranslate)
-
     updatedProjection.scale(updatedScale * (WIDTH / (2 * Math.PI)))
     updatedProjection.translate([
       ((1 + updatedTranslate[0]) * WIDTH) / 2,

--- a/src/raster.js
+++ b/src/raster.js
@@ -352,6 +352,7 @@ const Raster = ({
     invalidated.current = 'on prop change'
   }, [
     clim && clim[0],
+    clim && clim[1],
     mode,
     scale,
     translate[0],


### PR DESCRIPTION
This PR extends the the changes in https://github.com/carbonplan/minimaps/pull/10 to also support rendering data from pre-fetched `source`s.
  - assumes Zarr data incoming from either `loadGroup` or `load`

In the process of making this change, it was noticed that rapid changes to multiple props that control rendering (e.g. `bounds` and `source`) can result in `redraw`s not getting picked up in the frameloop. This PR also includes a refactor which uses the `regl.frame` loop to ensure that another draw takes place whenever an `invalidated` value has been set.