### PR TITLE
Add demo that re-projects data on-the-fly

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -23,7 +23,8 @@
         "next": "^12.0.7",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "theme-ui": "^0.13.1"
+        "theme-ui": "^0.13.1",
+        "zarr-js": "^2.2.1"
       },
       "devDependencies": {
         "prettier": "^2.2.1"
@@ -93,9 +94,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "dependencies": {
         "@babel/types": "^7.18.10",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -278,9 +279,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.10.tgz",
-      "integrity": "sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg==",
+      "version": "7.18.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
+      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -365,9 +366,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.10.tgz",
-      "integrity": "sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==",
+      "version": "7.18.11",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
+      "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.10",
@@ -375,7 +376,7 @@
         "@babel/helper-function-name": "^7.18.9",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.10",
+        "@babel/parser": "^7.18.11",
         "@babel/types": "^7.18.10",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -776,9 +777,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.3.tgz",
-      "integrity": "sha512-2lWKP5Xcvnor70NaaROZXBvU8z9mFReePCG8NhZw6NyNGnPvC+8s+Cre/63LAB1LKzWw/e9bZJnQUg0gYFRb2Q=="
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.4.tgz",
+      "integrity": "sha512-/gApFXWk5CCLFQJL5IYJXxPQuG5tz5nPX4l27A9Zm/+wJxiwFrRSP54AopDxIv4JRp/rGwcgk/lZS/0Clw8jYA=="
     },
     "node_modules/@next/mdx": {
       "version": "11.1.4",
@@ -790,9 +791,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.3.tgz",
-      "integrity": "sha512-JxmCW9XB5PYnkGE67BdnBTdqW0SW6oMCiPMHLdjeRi4T3U4JJKJGnjQld99+6TPOfPWigtw3W7Cijp5gc+vJ/w==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.4.tgz",
+      "integrity": "sha512-P4YSFNpmXXSnn3P1qsOAqz+MX3On9fHrlc8ovb/CFJJoU+YLCR53iCEwfw39e0IZEgDA7ttgr108plF8mxaX0g==",
       "cpu": [
         "arm"
       ],
@@ -805,9 +806,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.3.tgz",
-      "integrity": "sha512-3l4zXpWnzy0fqoedsFRxzMy/eGlMMqn6IwPEuBmtEQ4h7srmQFHyT+Bk+eVHb0o1RQ7/TloAa+mu8JX5tz/5tA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.4.tgz",
+      "integrity": "sha512-4o2n14E18O+8xHlf6dgJsWPXN9gmSmfIe2Z0EqKDIPBBkFt/2CyrH0+vwHnL2l7xkDHhOGfZYcYIWVUR5aNu0A==",
       "cpu": [
         "arm64"
       ],
@@ -820,9 +821,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.3.tgz",
-      "integrity": "sha512-eutDO/RH6pf7+8zHo3i2GKLhF0qaMtxWpY8k3Oa1k+CyrcJ0IxwkfH/x3f75jTMeCrThn6Uu8j3WeZOxvhto1Q==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.4.tgz",
+      "integrity": "sha512-DcUO6MGBL9E3jj5o86MUnTOy4WawIJJhyCcFYO4f51sbl7+uPIYIx40eo98A6NwJEXazCqq1hLeqOaNTAIvDiQ==",
       "cpu": [
         "arm64"
       ],
@@ -835,9 +836,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.3.tgz",
-      "integrity": "sha512-lve+lnTiddXbcT3Lh2ujOFywQSEycTYQhuf6j6JrPu9oLQGS01kjIqqSj3/KMmSoppEnXo3BxkgYu+g2+ecHkA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.4.tgz",
+      "integrity": "sha512-IUlFMqeLjdIzDorrGC2Dt+2Ae3DbKQbRzCzmDq4/CP1+jJGeDXo/2AHnlE+WYnwQAC4KtAz6pbVnd3KstZWsVA==",
       "cpu": [
         "x64"
       ],
@@ -850,9 +851,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.3.tgz",
-      "integrity": "sha512-V4bZU1qBFkULTPW53phY8ypioh3EERzHu9YKAasm9RxU4dj+8c/4s60y+kbFkFEEpIUgEU6yNuYZRR4lHHbUGA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.4.tgz",
+      "integrity": "sha512-475vwyWcjnyDVDWLgAATP0HI8W1rwByc+uXk1B6KkAVFhkoDgH387LW0uNqxavK+VxCzj3avQXX/58XDvxtSlg==",
       "cpu": [
         "x64"
       ],
@@ -865,9 +866,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.3.tgz",
-      "integrity": "sha512-MWxS/i+XSEKdQE0ZmdYkPPrWKBi4JwMVaXdOW9J/T/sZJsHsLlSC9ErBcNolKAJEVka+tnw9oPRyRCKOj+q0sw==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.4.tgz",
+      "integrity": "sha512-qZW+L3iG3XSGtlOPmD5RRWXyk6ZNdscLV0BQjuDvP+exTg+uixqHXOHz0/GVATIJEBQOF0Kew7jAXVXEP+iRTQ==",
       "cpu": [
         "arm"
       ],
@@ -880,9 +881,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.3.tgz",
-      "integrity": "sha512-ikXkqAmvEcWTzIQFDdmrUHLWzdDAF5s2pVsSpQn9rk/gK1i9webH1GRQd2bSM7JLuPBZSaYrNGvDTyHZdSEYlg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.4.tgz",
+      "integrity": "sha512-fEPRjItWYaKyyG9N+2HIA59OBHIhk7WC+Rh+LwXsh0pQe870Ykpek3KQs0umjsrEGe57NyMomq3f80/N8taDvA==",
       "cpu": [
         "arm64"
       ],
@@ -895,9 +896,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.3.tgz",
-      "integrity": "sha512-wE45gGFkeLLLnCoveKaBrdpYkkypl3qwNF2YhnfvfVK7etuu1O679LwClhCWinDVBr+KOkmyHok00Z+0uI1ycg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.4.tgz",
+      "integrity": "sha512-rnCTzXII0EBCcFn9P5s/Dho2kPUMSX/bP0iOAj8wEI/IxUEfEElbin89zJoNW30cycHu19xY8YP4K2+hzciPzQ==",
       "cpu": [
         "arm64"
       ],
@@ -910,9 +911,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.3.tgz",
-      "integrity": "sha512-MbFI6413VSXiREzHwYD8YAJLTknBaC+bmjXgdHEEdloeOuBFQGE3NWn3izOCTy8kV+s98VDQO8au7EKKs+bW0g==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.4.tgz",
+      "integrity": "sha512-PhXX6NSuIuhHInxPY2VkG2Bl7VllsD3Cjx+pQcS1wTym7Zt7UoLvn05PkRrkiyIkvR+UXnqPUM3TYiSbnemXEw==",
       "cpu": [
         "x64"
       ],
@@ -925,9 +926,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.3.tgz",
-      "integrity": "sha512-jMBD0Va6fInbPih/dNySlNY2RpjkK6MXS+UGVEvuTswl1MZr+iahvurmshwGKpjaRwVU4DSFMD8+gfWxsTFs1Q==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.4.tgz",
+      "integrity": "sha512-GmC/QROiUZpFirHRfPQqMyCXZ+5+ndbBZrMvL74HtQB/CKXB8K1VM+rvy9Gp/5OaU8Rxp48IcX79NOfI2LiXlA==",
       "cpu": [
         "x64"
       ],
@@ -940,9 +941,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.3.tgz",
-      "integrity": "sha512-Cq8ToPdc0jQP2C7pjChYctAsEe7+lO/B826ZCK5xFzobuHPiCyJ2Mzx/nEQwCY4SpYkeJQtCbwlCz5iyGW5zGg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.4.tgz",
+      "integrity": "sha512-9XKoCXbNZuaMRPtcKQz3+hgVpkMosaLlcxHFXT8/j4w61k7/qvEbrkMDS9WHNrD/xVcLycwhPRgXcns2K1BdBQ==",
       "cpu": [
         "arm64"
       ],
@@ -955,9 +956,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.3.tgz",
-      "integrity": "sha512-BtFq4c8IpeB0sDhJMHJFgm86rPkOvmYI8k3De8Y2kgNVWSeLQ0Q929PWf7e+GqcX1015ei/gEB41ZH8Iw49NzA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.4.tgz",
+      "integrity": "sha512-hEyRieZKH9iw4AzvXaQ+Fyb98k0G/o9QcRGxA1/O/O/elf1+Qvuwb15phT8GbVtIeNziy66XTPOhKKfdr8KyUg==",
       "cpu": [
         "ia32"
       ],
@@ -970,9 +971,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.3.tgz",
-      "integrity": "sha512-huSNb98KSG77Kl96CoPgCwom28aamuUsPpRmn/4s9L0RNbbHVSkp9E6HA4yOAykZCEuWcdNsRLbVVuAbt8rtIw==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.4.tgz",
+      "integrity": "sha512-5Pl1tdMJWLy4rvzU1ecx0nHWgDPqoYuvYoXE/5X0Clu9si/yOuBIj573F2kOTY7mu0LX2wgCJVSnyK0abHBxIw==",
       "cpu": [
         "x64"
       ],
@@ -1422,9 +1423,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001373",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
+      "version": "1.0.30001374",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
+      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1659,9 +1660,9 @@
       "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.210",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
-      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==",
+      "version": "1.4.211",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
+      "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
       "peer": true
     },
     "node_modules/emojis-list": {
@@ -1970,9 +1971,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2222,11 +2223,11 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/next": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.2.3.tgz",
-      "integrity": "sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.2.4.tgz",
+      "integrity": "sha512-b1xlxEozmAWokAXzXsi5vlmU/IfJcFNIJA8dpU5UdkFbyDPio8wwb8mAQ/Y7rGtfTgG/t/u49BiyEA+xAgFvow==",
       "dependencies": {
-        "@next/env": "12.2.3",
+        "@next/env": "12.2.4",
         "@swc/helpers": "0.4.3",
         "caniuse-lite": "^1.0.30001332",
         "postcss": "8.4.14",
@@ -2240,19 +2241,19 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.2.3",
-        "@next/swc-android-arm64": "12.2.3",
-        "@next/swc-darwin-arm64": "12.2.3",
-        "@next/swc-darwin-x64": "12.2.3",
-        "@next/swc-freebsd-x64": "12.2.3",
-        "@next/swc-linux-arm-gnueabihf": "12.2.3",
-        "@next/swc-linux-arm64-gnu": "12.2.3",
-        "@next/swc-linux-arm64-musl": "12.2.3",
-        "@next/swc-linux-x64-gnu": "12.2.3",
-        "@next/swc-linux-x64-musl": "12.2.3",
-        "@next/swc-win32-arm64-msvc": "12.2.3",
-        "@next/swc-win32-ia32-msvc": "12.2.3",
-        "@next/swc-win32-x64-msvc": "12.2.3"
+        "@next/swc-android-arm-eabi": "12.2.4",
+        "@next/swc-android-arm64": "12.2.4",
+        "@next/swc-darwin-arm64": "12.2.4",
+        "@next/swc-darwin-x64": "12.2.4",
+        "@next/swc-freebsd-x64": "12.2.4",
+        "@next/swc-linux-arm-gnueabihf": "12.2.4",
+        "@next/swc-linux-arm64-gnu": "12.2.4",
+        "@next/swc-linux-arm64-musl": "12.2.4",
+        "@next/swc-linux-x64-gnu": "12.2.4",
+        "@next/swc-linux-x64-musl": "12.2.4",
+        "@next/swc-win32-arm64-msvc": "12.2.4",
+        "@next/swc-win32-ia32-msvc": "12.2.4",
+        "@next/swc-win32-x64-msvc": "12.2.4"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -3322,9 +3323,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "requires": {
         "@babel/types": "^7.18.10",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -3458,9 +3459,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.10.tgz",
-      "integrity": "sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg=="
+      "version": "7.18.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
+      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ=="
     },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.12.1",
@@ -3515,9 +3516,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.10.tgz",
-      "integrity": "sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==",
+      "version": "7.18.11",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
+      "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.10",
@@ -3525,7 +3526,7 @@
         "@babel/helper-function-name": "^7.18.9",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.10",
+        "@babel/parser": "^7.18.11",
         "@babel/types": "^7.18.10",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -3826,9 +3827,9 @@
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA=="
     },
     "@next/env": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.3.tgz",
-      "integrity": "sha512-2lWKP5Xcvnor70NaaROZXBvU8z9mFReePCG8NhZw6NyNGnPvC+8s+Cre/63LAB1LKzWw/e9bZJnQUg0gYFRb2Q=="
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.4.tgz",
+      "integrity": "sha512-/gApFXWk5CCLFQJL5IYJXxPQuG5tz5nPX4l27A9Zm/+wJxiwFrRSP54AopDxIv4JRp/rGwcgk/lZS/0Clw8jYA=="
     },
     "@next/mdx": {
       "version": "11.1.4",
@@ -3837,81 +3838,81 @@
       "requires": {}
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.3.tgz",
-      "integrity": "sha512-JxmCW9XB5PYnkGE67BdnBTdqW0SW6oMCiPMHLdjeRi4T3U4JJKJGnjQld99+6TPOfPWigtw3W7Cijp5gc+vJ/w==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.4.tgz",
+      "integrity": "sha512-P4YSFNpmXXSnn3P1qsOAqz+MX3On9fHrlc8ovb/CFJJoU+YLCR53iCEwfw39e0IZEgDA7ttgr108plF8mxaX0g==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.3.tgz",
-      "integrity": "sha512-3l4zXpWnzy0fqoedsFRxzMy/eGlMMqn6IwPEuBmtEQ4h7srmQFHyT+Bk+eVHb0o1RQ7/TloAa+mu8JX5tz/5tA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.4.tgz",
+      "integrity": "sha512-4o2n14E18O+8xHlf6dgJsWPXN9gmSmfIe2Z0EqKDIPBBkFt/2CyrH0+vwHnL2l7xkDHhOGfZYcYIWVUR5aNu0A==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.3.tgz",
-      "integrity": "sha512-eutDO/RH6pf7+8zHo3i2GKLhF0qaMtxWpY8k3Oa1k+CyrcJ0IxwkfH/x3f75jTMeCrThn6Uu8j3WeZOxvhto1Q==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.4.tgz",
+      "integrity": "sha512-DcUO6MGBL9E3jj5o86MUnTOy4WawIJJhyCcFYO4f51sbl7+uPIYIx40eo98A6NwJEXazCqq1hLeqOaNTAIvDiQ==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.3.tgz",
-      "integrity": "sha512-lve+lnTiddXbcT3Lh2ujOFywQSEycTYQhuf6j6JrPu9oLQGS01kjIqqSj3/KMmSoppEnXo3BxkgYu+g2+ecHkA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.4.tgz",
+      "integrity": "sha512-IUlFMqeLjdIzDorrGC2Dt+2Ae3DbKQbRzCzmDq4/CP1+jJGeDXo/2AHnlE+WYnwQAC4KtAz6pbVnd3KstZWsVA==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.3.tgz",
-      "integrity": "sha512-V4bZU1qBFkULTPW53phY8ypioh3EERzHu9YKAasm9RxU4dj+8c/4s60y+kbFkFEEpIUgEU6yNuYZRR4lHHbUGA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.4.tgz",
+      "integrity": "sha512-475vwyWcjnyDVDWLgAATP0HI8W1rwByc+uXk1B6KkAVFhkoDgH387LW0uNqxavK+VxCzj3avQXX/58XDvxtSlg==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.3.tgz",
-      "integrity": "sha512-MWxS/i+XSEKdQE0ZmdYkPPrWKBi4JwMVaXdOW9J/T/sZJsHsLlSC9ErBcNolKAJEVka+tnw9oPRyRCKOj+q0sw==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.4.tgz",
+      "integrity": "sha512-qZW+L3iG3XSGtlOPmD5RRWXyk6ZNdscLV0BQjuDvP+exTg+uixqHXOHz0/GVATIJEBQOF0Kew7jAXVXEP+iRTQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.3.tgz",
-      "integrity": "sha512-ikXkqAmvEcWTzIQFDdmrUHLWzdDAF5s2pVsSpQn9rk/gK1i9webH1GRQd2bSM7JLuPBZSaYrNGvDTyHZdSEYlg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.4.tgz",
+      "integrity": "sha512-fEPRjItWYaKyyG9N+2HIA59OBHIhk7WC+Rh+LwXsh0pQe870Ykpek3KQs0umjsrEGe57NyMomq3f80/N8taDvA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.3.tgz",
-      "integrity": "sha512-wE45gGFkeLLLnCoveKaBrdpYkkypl3qwNF2YhnfvfVK7etuu1O679LwClhCWinDVBr+KOkmyHok00Z+0uI1ycg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.4.tgz",
+      "integrity": "sha512-rnCTzXII0EBCcFn9P5s/Dho2kPUMSX/bP0iOAj8wEI/IxUEfEElbin89zJoNW30cycHu19xY8YP4K2+hzciPzQ==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.3.tgz",
-      "integrity": "sha512-MbFI6413VSXiREzHwYD8YAJLTknBaC+bmjXgdHEEdloeOuBFQGE3NWn3izOCTy8kV+s98VDQO8au7EKKs+bW0g==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.4.tgz",
+      "integrity": "sha512-PhXX6NSuIuhHInxPY2VkG2Bl7VllsD3Cjx+pQcS1wTym7Zt7UoLvn05PkRrkiyIkvR+UXnqPUM3TYiSbnemXEw==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.3.tgz",
-      "integrity": "sha512-jMBD0Va6fInbPih/dNySlNY2RpjkK6MXS+UGVEvuTswl1MZr+iahvurmshwGKpjaRwVU4DSFMD8+gfWxsTFs1Q==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.4.tgz",
+      "integrity": "sha512-GmC/QROiUZpFirHRfPQqMyCXZ+5+ndbBZrMvL74HtQB/CKXB8K1VM+rvy9Gp/5OaU8Rxp48IcX79NOfI2LiXlA==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.3.tgz",
-      "integrity": "sha512-Cq8ToPdc0jQP2C7pjChYctAsEe7+lO/B826ZCK5xFzobuHPiCyJ2Mzx/nEQwCY4SpYkeJQtCbwlCz5iyGW5zGg==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.4.tgz",
+      "integrity": "sha512-9XKoCXbNZuaMRPtcKQz3+hgVpkMosaLlcxHFXT8/j4w61k7/qvEbrkMDS9WHNrD/xVcLycwhPRgXcns2K1BdBQ==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.3.tgz",
-      "integrity": "sha512-BtFq4c8IpeB0sDhJMHJFgm86rPkOvmYI8k3De8Y2kgNVWSeLQ0Q929PWf7e+GqcX1015ei/gEB41ZH8Iw49NzA==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.4.tgz",
+      "integrity": "sha512-hEyRieZKH9iw4AzvXaQ+Fyb98k0G/o9QcRGxA1/O/O/elf1+Qvuwb15phT8GbVtIeNziy66XTPOhKKfdr8KyUg==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.3.tgz",
-      "integrity": "sha512-huSNb98KSG77Kl96CoPgCwom28aamuUsPpRmn/4s9L0RNbbHVSkp9E6HA4yOAykZCEuWcdNsRLbVVuAbt8rtIw==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.4.tgz",
+      "integrity": "sha512-5Pl1tdMJWLy4rvzU1ecx0nHWgDPqoYuvYoXE/5X0Clu9si/yOuBIj573F2kOTY7mu0LX2wgCJVSnyK0abHBxIw==",
       "optional": true
     },
     "@styled-system/background": {
@@ -4280,9 +4281,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001373",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
+      "version": "1.0.30001374",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
+      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw=="
     },
     "cartesian-product": {
       "version": "2.1.2",
@@ -4459,9 +4460,9 @@
       "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
     },
     "electron-to-chromium": {
-      "version": "1.4.210",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
-      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==",
+      "version": "1.4.211",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
+      "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
       "peer": true
     },
     "emojis-list": {
@@ -4684,9 +4685,9 @@
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -4873,24 +4874,24 @@
       }
     },
     "next": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.2.3.tgz",
-      "integrity": "sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.2.4.tgz",
+      "integrity": "sha512-b1xlxEozmAWokAXzXsi5vlmU/IfJcFNIJA8dpU5UdkFbyDPio8wwb8mAQ/Y7rGtfTgG/t/u49BiyEA+xAgFvow==",
       "requires": {
-        "@next/env": "12.2.3",
-        "@next/swc-android-arm-eabi": "12.2.3",
-        "@next/swc-android-arm64": "12.2.3",
-        "@next/swc-darwin-arm64": "12.2.3",
-        "@next/swc-darwin-x64": "12.2.3",
-        "@next/swc-freebsd-x64": "12.2.3",
-        "@next/swc-linux-arm-gnueabihf": "12.2.3",
-        "@next/swc-linux-arm64-gnu": "12.2.3",
-        "@next/swc-linux-arm64-musl": "12.2.3",
-        "@next/swc-linux-x64-gnu": "12.2.3",
-        "@next/swc-linux-x64-musl": "12.2.3",
-        "@next/swc-win32-arm64-msvc": "12.2.3",
-        "@next/swc-win32-ia32-msvc": "12.2.3",
-        "@next/swc-win32-x64-msvc": "12.2.3",
+        "@next/env": "12.2.4",
+        "@next/swc-android-arm-eabi": "12.2.4",
+        "@next/swc-android-arm64": "12.2.4",
+        "@next/swc-darwin-arm64": "12.2.4",
+        "@next/swc-darwin-x64": "12.2.4",
+        "@next/swc-freebsd-x64": "12.2.4",
+        "@next/swc-linux-arm-gnueabihf": "12.2.4",
+        "@next/swc-linux-arm64-gnu": "12.2.4",
+        "@next/swc-linux-arm64-musl": "12.2.4",
+        "@next/swc-linux-x64-gnu": "12.2.4",
+        "@next/swc-linux-x64-musl": "12.2.4",
+        "@next/swc-win32-arm64-msvc": "12.2.4",
+        "@next/swc-win32-ia32-msvc": "12.2.4",
+        "@next/swc-win32-x64-msvc": "12.2.4",
         "@swc/helpers": "0.4.3",
         "caniuse-lite": "^1.0.30001332",
         "postcss": "8.4.14",

--- a/demo/package.json
+++ b/demo/package.json
@@ -30,7 +30,8 @@
     "next": "^12.0.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "theme-ui": "^0.13.1"
+    "theme-ui": "^0.13.1",
+    "zarr-js": "^2.2.1"
   },
   "devDependencies": {
     "prettier": "^2.2.1"

--- a/demo/pages/test-leap.js
+++ b/demo/pages/test-leap.js
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { Minimap, Path, Sphere, Raster } from '@carbonplan/minimaps'
+import {
+  naturalEarth1,
+  orthographic,
+  mercator,
+  equirectangular,
+} from '@carbonplan/minimaps/projections'
+import { useThemeUI, Box, Flex } from 'theme-ui'
+import { Toggle, Select } from '@carbonplan/components'
+import { useThemedColormap } from '@carbonplan/colormaps'
+import { datasets } from '../datasets'
+
+const projections = {
+  naturalEarth1,
+  orthographic,
+  mercator,
+  equirectangular,
+}
+
+const Test = () => {
+  const { theme } = useThemeUI()
+  const [projection, setProjection] = useState('naturalEarth1')
+  const [basemaps, setBasemaps] = useState({
+    land: true,
+    ocean: false,
+  })
+  const colormap = useThemedColormap('cool', { count: 255, format: 'rgb' })
+
+  return (
+    <>
+      <Box sx={{ width: '200px', mt: [2], ml: [4] }}>
+        <Select onChange={(e) => setProjection(e.target.value)}>
+          <option value='naturalEarth1'>naturalEarth1</option>
+          <option value='orthographic'>orthographic</option>
+          <option value='mercator'>mercator</option>
+          <option value='equirectangular'>equirectangular</option>
+        </Select>
+
+        <Flex sx={{ gap: 2 }}>
+          Land
+          <Toggle
+            value={basemaps.land}
+            onClick={() => setBasemaps((v) => ({ ...v, land: !v.land }))}
+          />
+        </Flex>
+
+        <Flex sx={{ gap: 2 }}>
+          Ocean
+          <Toggle
+            value={basemaps.ocean}
+            onClick={() => setBasemaps((v) => ({ ...v, ocean: !v.ocean }))}
+          />
+        </Flex>
+      </Box>
+
+      <Box sx={{ width: '50%', ml: [4], mt: [6], mb: [3] }}>
+        <Minimap
+          projection={projections[projection]}
+          scale={1}
+          translate={[0, 0]}
+        >
+          {basemaps.ocean && (
+            <Path
+              fill={theme.colors.background}
+              opacity={1}
+              source={
+                'https://storage.googleapis.com/carbonplan-maps/world-atlas/ocean-50m.json'
+              }
+              feature={'ocean'}
+            />
+          )}
+
+          {basemaps.land && (
+            <Path
+              stroke={theme.colors.primary}
+              source={
+                'https://cdn.jsdelivr.net/npm/world-atlas@2/land-50m.json'
+              }
+              feature={'land'}
+              opacity={1}
+            />
+          )}
+
+          <Sphere fill={theme.colors.background} />
+          <Raster
+            source={datasets['gcm_central-america.zarr']}
+            colormap={colormap}
+            mode={'lut'}
+            clim={[280, 310]}
+            nullValue={9.969209968386869e36}
+            variable={'tasmax'}
+          />
+        </Minimap>
+      </Box>
+    </>
+  )
+}
+
+export default Test

--- a/demo/pages/test-leap.js
+++ b/demo/pages/test-leap.js
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import zarr from 'zarr-js'
 import { Minimap, Path, Sphere, Raster } from '@carbonplan/minimaps'
 import {
   naturalEarth1,
@@ -9,7 +10,6 @@ import {
 import { useThemeUI, Box, Flex } from 'theme-ui'
 import { Toggle, Select } from '@carbonplan/components'
 import { useThemedColormap } from '@carbonplan/colormaps'
-import { datasets } from '../datasets'
 
 const projections = {
   naturalEarth1,
@@ -18,14 +18,51 @@ const projections = {
   equirectangular,
 }
 
+const DATASET =
+  'https://cmip6downscaling.blob.core.windows.net/vis/article/fig1/regions/central-america/gcm-tasmax.zarr'
+const VARIABLE = 'tasmax'
+const NAN = 9.969209968386869e36
+
+const fetchData = () => {
+  return new Promise((resolve) =>
+    zarr().loadGroup(
+      DATASET,
+      (error, { [VARIABLE]: data, lat, lon }) => {
+        const bounds = {
+          lat: [
+            lat.data.reduce((a, b) => Math.min(a, b)),
+            lat.data.reduce((a, b) => Math.max(a, b)),
+          ],
+          lon: [
+            lon.data.reduce((a, b) => Math.min(a, b)),
+            lon.data.reduce((a, b) => Math.max(a, b)),
+          ],
+        }
+
+        resolve({ data, bounds })
+      },
+      [VARIABLE, 'lat', 'lon']
+    )
+  )
+}
+
 const Test = () => {
   const { theme } = useThemeUI()
+  const colormap = useThemedColormap('cool', { count: 255, format: 'rgb' })
+  const [data, setData] = useState()
+  const [bounds, setBounds] = useState()
   const [projection, setProjection] = useState('naturalEarth1')
   const [basemaps, setBasemaps] = useState({
     land: true,
     ocean: false,
   })
-  const colormap = useThemedColormap('cool', { count: 255, format: 'rgb' })
+
+  useEffect(() => {
+    fetchData().then((result) => {
+      setData(result.data)
+      setBounds(result.bounds)
+    })
+  }, [])
 
   return (
     <>
@@ -55,43 +92,46 @@ const Test = () => {
       </Box>
 
       <Box sx={{ width: '50%', ml: [4], mt: [6], mb: [3] }}>
-        <Minimap
-          projection={projections[projection]}
-          scale={1}
-          translate={[0, 0]}
-        >
-          {basemaps.ocean && (
-            <Path
-              fill={theme.colors.background}
-              opacity={1}
-              source={
-                'https://storage.googleapis.com/carbonplan-maps/world-atlas/ocean-50m.json'
-              }
-              feature={'ocean'}
-            />
-          )}
+        {data && bounds && (
+          <Minimap
+            projection={projections[projection]}
+            scale={1}
+            translate={[0, 0]}
+          >
+            {basemaps.ocean && (
+              <Path
+                fill={theme.colors.background}
+                opacity={1}
+                source={
+                  'https://storage.googleapis.com/carbonplan-maps/world-atlas/ocean-50m.json'
+                }
+                feature={'ocean'}
+              />
+            )}
 
-          {basemaps.land && (
-            <Path
-              stroke={theme.colors.primary}
-              source={
-                'https://cdn.jsdelivr.net/npm/world-atlas@2/land-50m.json'
-              }
-              feature={'land'}
-              opacity={1}
-            />
-          )}
+            {basemaps.land && (
+              <Path
+                stroke={theme.colors.primary}
+                source={
+                  'https://cdn.jsdelivr.net/npm/world-atlas@2/land-50m.json'
+                }
+                feature={'land'}
+                opacity={1}
+              />
+            )}
 
-          <Sphere fill={theme.colors.background} />
-          <Raster
-            source={datasets['gcm_central-america.zarr']}
-            colormap={colormap}
-            mode={'lut'}
-            clim={[280, 310]}
-            nullValue={9.969209968386869e36}
-            variable={'tasmax'}
-          />
-        </Minimap>
+            <Sphere fill={theme.colors.background} />
+
+            <Raster
+              source={data}
+              bounds={bounds}
+              colormap={colormap}
+              mode={'lut'}
+              clim={[280, 310]}
+              nullValue={NAN}
+            />
+          </Minimap>
+        )}
       </Box>
     </>
   )

--- a/src/regl.js
+++ b/src/regl.js
@@ -34,7 +34,7 @@ const Regl = ({ style, aspect, children }) => {
               : container.current.style.height,
             width: container.current.offsetWidth,
           }),
-        10
+        0
       )
     }
     window.addEventListener('resize', resize.current)

--- a/src/regl.js
+++ b/src/regl.js
@@ -28,11 +28,14 @@ const Regl = ({ style, aspect, children }) => {
           resize()
         })
         resize()
-        regl.current = _regl({
-          container: node,
-          extensions: ['OES_texture_float', 'OES_element_index_uint'],
-        })
-        setReady(true)
+
+        if (!regl.current) {
+          regl.current = _regl({
+            container: node,
+            extensions: ['OES_texture_float', 'OES_element_index_uint'],
+          })
+          setReady(true)
+        }
       }
     },
     [aspect]


### PR DESCRIPTION
- Sets up new `test-leap` using CMIP6 demo data
  - Fetches data and calculates `zoom`, `translate`, and `bounds` outside of `minimaps`
- Makes a few tweaks to library to support this case
  - Redefines `draw` method every time projection changes
  - Clears the draw buffer on every invalidation
  - Makes `viewport` tracking the explicit responsibility of `Raster`
    - Avoids usage of stale `context` values read in `draw` calls
    - Relies on temporary `setTimeout` hack to workaround stale draws when multiple projection-related props are updated at once (`aspect` and other props in this case)