### PR TITLE
Support reprojection

### DIFF
--- a/src/regl.js
+++ b/src/regl.js
@@ -34,7 +34,7 @@ const Regl = ({ style, aspect, children }) => {
               : container.current.style.height,
             width: container.current.offsetWidth,
           }),
-        10
+        0
       )
     }
     window.addEventListener('resize', resize.current)

--- a/src/regl.js
+++ b/src/regl.js
@@ -26,16 +26,12 @@ const Regl = ({ style, aspect, children }) => {
       container.current.style.height =
         container.current.offsetWidth * aspect + 'px'
 
-      setTimeout(
-        () =>
-          setViewport({
-            height: container.current.offsetWidth
-              ? container.current.offsetWidth * aspect
-              : container.current.style.height,
-            width: container.current.offsetWidth,
-          }),
-        0
-      )
+      setViewport({
+        height: container.current.offsetWidth
+          ? container.current.offsetWidth * aspect
+          : container.current.style.height,
+        width: container.current.offsetWidth,
+      })
     }
     window.addEventListener('resize', resize.current)
     resize.current()

--- a/src/regl.js
+++ b/src/regl.js
@@ -28,11 +28,14 @@ const Regl = ({ style, aspect, children }) => {
           resize()
         })
         resize()
-        regl.current = _regl({
-          container: node,
-          extensions: ['OES_texture_float', 'OES_element_index_uint'],
-        })
-        setReady(true)
+
+        if (!regl.current) {
+          regl.current = _regl({
+            container: node,
+            extensions: ['OES_texture_float', 'OES_element_index_uint'],
+          })
+          setReady(true)
+        }
       }
     },
     [aspect]


### PR DESCRIPTION
Makes a few tweaks to support on-the-fly `projection` updates (https://github.com/carbonplan/minimaps/pull/14)

- Redefines `draw` method every time projection changes
- Clears the draw buffer on every invalidation
- Avoids silently dropping old `regl` references on every `aspect` change
- Makes `viewport` tracking the explicit responsibility of `Regl` + `Raster`
  - Avoids usage of stale `context` values read in `draw` calls in `Raster`