### PR TITLE
Handling rotated datasets

### DIFF
--- a/src/raster.js
+++ b/src/raster.js
@@ -180,8 +180,8 @@ const Raster = ({
         vec2 lookup = ${projection.glsl.name}(x, y);
 
         // Calculate rotation based of north pole coordinates of rotated grid
-        float theta = -1.0 * (90.0 + northPole.y);
-        float phi = -1.0 * northPole.x;
+        float theta = radians(90.0 - northPole.y);
+        float phi = radians(-1.0 * northPole.x);
 
         float lat = radians(lookup.y);
         float lon = radians(lookup.x);
@@ -189,7 +189,7 @@ const Raster = ({
         // Convert from spherical to cartesian coordinates
         vec3 unrotatedCoord = vec3(cos(lon) * cos(lat), sin(lon) * cos(lat), sin(lat));
 
-        // Rotation matrix
+        // Rotation matrix based on https://www.mathworks.com/matlabcentral/fileexchange/43435-rotated-grid-transform
         mat3 rotation = mat3(
           cos(theta) * cos(phi)       , cos(theta) * sin(phi)       , sin(theta),
           -1.0 * sin(phi)             , cos(phi)                    , 0         ,

--- a/src/raster.js
+++ b/src/raster.js
@@ -191,7 +191,7 @@ const Raster = ({
 
         // Rotation matrix
         mat3 rotation = mat3(
-          cos(theta) * cos(phi)       , -1.0 * cos(theta) * sin(phi), sin(theta),
+          cos(theta) * cos(phi)       , cos(theta) * sin(phi)       , sin(theta),
           -1.0 * sin(phi)             , cos(phi)                    , 0         ,
           -1.0 * sin(theta) * cos(phi), -1.0 * sin(theta) * sin(phi), cos(theta)
         );

--- a/src/raster.js
+++ b/src/raster.js
@@ -162,7 +162,8 @@ const Raster = ({
 
       vec2 rotateCoords(vec2 coords, vec2 northPole) {
         // Calculate rotation based of north pole coordinates of rotated grid
-        float phi = radians(180.0 + northPole.x); // TODO: avoid hardcoding 180deg offset
+        float phiOffset = northPole.y == 90.0 ? 0.0 : 180.0;
+        float phi = radians(phiOffset + northPole.x);
         float theta = radians(-1.0 * (90.0 - northPole.y));
 
         float lon = radians(coords.x);

--- a/src/raster.js
+++ b/src/raster.js
@@ -188,8 +188,8 @@ const Raster = ({
         vec3 unrotatedCoord = vec3(cos(lon) * cos(lat), sin(lon) * cos(lat), sin(lat));
 
         mat3 rotation = mat3(
-          cos(theta) * cos(phi), -1.0 * cos(theta) * sin(phi), sin(theta),
-          -1.0 * sin(phi)             , cos(phi)                    , 0                ,
+          cos(theta) * cos(phi)       , -1.0 * cos(theta) * sin(phi), sin(theta),
+          -1.0 * sin(phi)             , cos(phi)                    , 0         ,
           -1.0 * sin(theta) * cos(phi), -1.0 * sin(theta) * sin(phi), cos(theta)
         );
 

--- a/src/raster.js
+++ b/src/raster.js
@@ -181,16 +181,21 @@ const Raster = ({
         float translateY = 90.0 + bounds[0];
         float translateX = 180.0 + bounds[2];
 
+        float offsetX = 0.0;
+        if (lookup.x < bounds[2]) {
+          offsetX = 360.0;
+        }
+
         ${
           transpose
-            ? `rescaled = vec2(scaleX * (radians(lookup.x - translateX) + pi) / twoPi, scaleY * (radians(lookup.y - translateY) + halfPi) / (pi));`
-            : `rescaled = vec2(scaleY * (radians(lookup.y - translateY) + halfPi) / (pi), scaleX * (radians(lookup.x - translateX) + pi) / twoPi);`
+            ? `rescaled = vec2(scaleX * (radians(lookup.x + offsetX - translateX) + pi) / twoPi, scaleY * (radians(lookup.y - translateY) + halfPi) / (pi));`
+            : `rescaled = vec2(scaleY * (radians(lookup.y - translateY) + halfPi) / (pi), scaleX * (radians(lookup.x + offsetX - translateX) + pi) / twoPi);`
         }
 
         vec4 value = texture2D(texture, rescaled);
 
         bool inboundsY = lookup.y > bounds[0] && lookup.y < bounds[1];
-        bool inboundsX = lookup.x > bounds[2] && lookup.x < bounds[3];
+        bool inboundsX = lookup.x + offsetX > bounds[2] && lookup.x + offsetX < bounds[3];
 
         ${
           mode === 'lut'
@@ -200,7 +205,7 @@ const Raster = ({
             gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
           } else {
             float rescaled = (value.x - clim.x)/(clim.y - clim.x);
-            c = texture2D(lut, vec2(rescaled, 1.0));  
+            c = texture2D(lut, vec2(rescaled, 1.0));
             gl_FragColor = vec4(c.x, c.y, c.z, 1.0);
           }`
             : ''

--- a/src/raster.js
+++ b/src/raster.js
@@ -162,7 +162,7 @@ const Raster = ({
 
       vec2 rotateCoords(vec2 coords, vec2 northPole) {
         // Calculate rotation based of north pole coordinates of rotated grid
-        float phi = radians(-1.0 * northPole.x);
+        float phi = radians(180.0 + northPole.x); // TODO: avoid hardcoding 180deg offset
         float theta = radians(-1.0 * (90.0 - northPole.y));
 
         float lon = radians(coords.x);

--- a/src/raster.js
+++ b/src/raster.js
@@ -179,14 +179,17 @@ const Raster = ({
 
         vec2 lookup = ${projection.glsl.name}(x, y);
 
+        // Calculate rotation based of north pole coordinates of rotated grid
         float theta = -1.0 * (90.0 + northPole.y);
         float phi = -1.0 * northPole.x;
 
         float lat = radians(lookup.y);
         float lon = radians(lookup.x);
 
+        // Convert from spherical to cartesian coordinates
         vec3 unrotatedCoord = vec3(cos(lon) * cos(lat), sin(lon) * cos(lat), sin(lat));
 
+        // Rotation matrix
         mat3 rotation = mat3(
           cos(theta) * cos(phi)       , -1.0 * cos(theta) * sin(phi), sin(theta),
           -1.0 * sin(phi)             , cos(phi)                    , 0         ,
@@ -195,9 +198,11 @@ const Raster = ({
 
         vec3 rotatedCoord = rotation * unrotatedCoord;
 
+        // Convert from cartesian to spherical coordinates
         float rotatedY = degrees(asin(rotatedCoord.z));
         float rotatedX = degrees(atan(rotatedCoord.y, rotatedCoord.x));
 
+        // Handle points that wrap
         float offsetX = 0.0;
         if (rotatedX < bounds[2]) {
           offsetX = 360.0;

--- a/src/raster.js
+++ b/src/raster.js
@@ -189,14 +189,14 @@ const Raster = ({
         // Convert from spherical to cartesian coordinates
         vec3 unrotatedCoord = vec3(cos(lon) * cos(lat), sin(lon) * cos(lat), sin(lat));
 
-        // Rotation matrix based on https://www.mathworks.com/matlabcentral/fileexchange/43435-rotated-grid-transform
-        mat3 rotation = mat3(
-          cos(theta) * cos(phi)       , cos(theta) * sin(phi)       , sin(theta),
-          -1.0 * sin(phi)             , cos(phi)                    , 0         ,
-          -1.0 * sin(theta) * cos(phi), -1.0 * sin(theta) * sin(phi), cos(theta)
+        // From https://en.wikipedia.org/wiki/Rotation_matrix#General_rotations
+        mat3 intrinsicRotation = mat3(
+          cos(phi) * cos(theta), -1.0 * sin(phi), cos(phi) * sin(theta),
+          sin(phi) * cos(theta), cos(phi)       , sin(phi) * sin(theta),
+          -1.0 * sin(theta)    , 0              , cos(theta)
         );
 
-        vec3 rotatedCoord = rotation * unrotatedCoord;
+        vec3 rotatedCoord = intrinsicRotation * unrotatedCoord;
 
         // Convert from cartesian to spherical coordinates
         float rotatedY = degrees(asin(rotatedCoord.z));

--- a/src/raster.js
+++ b/src/raster.js
@@ -174,12 +174,12 @@ const Raster = ({
 
         vec2 lookup = ${projection.glsl.name}(x, y);
 
-        vec2 rescaled;
+        vec2 coord;
 
         float scaleY = 180.0 / abs(bounds[0] - bounds[1]);
         float scaleX = 360.0 / abs(bounds[2] - bounds[3]);
-        float translateY = 90.0 + bounds[0];
-        float translateX = 180.0 + bounds[2];
+        float translateY = bounds[0];
+        float translateX = bounds[2];
 
         float offsetX = 0.0;
         if (lookup.x < bounds[2]) {
@@ -188,11 +188,11 @@ const Raster = ({
 
         ${
           transpose
-            ? `rescaled = vec2(scaleX * (radians(lookup.x + offsetX - translateX) + pi) / twoPi, scaleY * (radians(lookup.y - translateY) + halfPi) / (pi));`
-            : `rescaled = vec2(scaleY * (radians(lookup.y - translateY) + halfPi) / (pi), scaleX * (radians(lookup.x + offsetX - translateX) + pi) / twoPi);`
+            ? `coord = vec2(scaleX * radians(lookup.x + offsetX - translateX) / twoPi, scaleY * radians(lookup.y - translateY) / pi);`
+            : `coord = vec2(scaleY * radians(lookup.y - translateY) / pi, scaleX * radians(lookup.x + offsetX - translateX) / twoPi);`
         }
 
-        vec4 value = texture2D(texture, rescaled);
+        vec4 value = texture2D(texture, coord);
 
         bool inboundsY = lookup.y > bounds[0] && lookup.y < bounds[1];
         bool inboundsX = lookup.x + offsetX > bounds[2] && lookup.x + offsetX < bounds[3];

--- a/src/raster.js
+++ b/src/raster.js
@@ -178,8 +178,8 @@ const Raster = ({
 
         float scaleY = 180.0 / abs(bounds[0] - bounds[1]);
         float scaleX = 360.0 / abs(bounds[2] - bounds[3]);
-        float translateY = bounds[0];
-        float translateX = bounds[2];
+        float translateY = 90.0 + bounds[0];
+        float translateX = 180.0 + bounds[2];
 
         float offsetX = 0.0;
         if (lookup.x < bounds[2]) {
@@ -188,8 +188,8 @@ const Raster = ({
 
         ${
           transpose
-            ? `coord = vec2(scaleX * radians(lookup.x + offsetX - translateX) / twoPi, scaleY * radians(lookup.y - translateY) / pi);`
-            : `coord = vec2(scaleY * radians(lookup.y - translateY) / pi, scaleX * radians(lookup.x + offsetX - translateX) / twoPi);`
+            ? `coord = vec2(scaleX * (radians(lookup.x + offsetX - translateX) + pi) / twoPi, scaleY * (radians(lookup.y - translateY) + halfPi) / (pi));`
+            : `coord = vec2(scaleY * (radians(lookup.y - translateY) + halfPi) / (pi), scaleX * (radians(lookup.x + offsetX - translateX) + pi) / twoPi);`
         }
 
         vec4 value = texture2D(texture, coord);

--- a/src/raster.js
+++ b/src/raster.js
@@ -206,6 +206,8 @@ const Raster = ({
         float offsetX = 0.0;
         if (rotatedX < bounds[2]) {
           offsetX = 360.0;
+        } else if (rotatedX > bounds[3]) {
+          offsetX = -360.0;
         }
 
         float scaleY = 180.0 / abs(bounds[0] - bounds[1]);

--- a/src/raster.js
+++ b/src/raster.js
@@ -29,6 +29,8 @@ const getBounds = ({ data, lat, lon }) => {
   }
 }
 
+const NORTH_POLE = [0, 90]
+
 const Raster = ({
   source,
   variable,
@@ -36,7 +38,7 @@ const Raster = ({
   colormap = null,
   clim = null,
   transpose,
-  northPole = [0, 90],
+  northPole = NORTH_POLE,
   nullValue = -999,
   bounds = null,
   lat = 'lat',


### PR DESCRIPTION
This PR adds support for datasets with rotated coordinate systems, specified via a new `northPole` prop (i.e. the north pole of the coordinate system). By default, the north pole is (0, 90). Using this north pole, the lookup coordinate is transformed by rotations along the Z and Y axes determined by the offset of the north pole.

Also handle datasets that do not fit neatly into (-180, 180) lon bounds by adding or subtracting 360deg when (potentially rotated) lookup is outside bounds.