### PR TITLE
Avoid constructing path multiple times

### DIFF
--- a/src/graticule.js
+++ b/src/graticule.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { geoPath, geoGraticule } from 'd3-geo'
 import { useMinimap } from './minimap'
+import useTransform from './use-transform'
 
 const Graticule = ({
   stroke,
@@ -8,12 +9,14 @@ const Graticule = ({
   step = [45, 45],
   opacity = 0.2,
 }) => {
-  const { projection, width, height } = useMinimap()
+  const { transform, ref } = useTransform()
+  const { projection } = useMinimap()
 
   const eps = projection.id === 'mercator' ? 0 : 0.1
 
   return (
     <path
+      ref={ref}
       d={geoPath(projection)(
         geoGraticule()
           .step(step)
@@ -22,13 +25,14 @@ const Graticule = ({
             [180 + eps, 90 + eps],
           ])()
       )}
-      stroke={stroke}
+      stroke={transform ? stroke : 'none'}
       fill={'none'}
       opacity={opacity}
       strokeWidth={strokeWidth}
       style={{
         vectorEffect: 'non-scaling-stroke',
       }}
+      transform={transform}
     />
   )
 }

--- a/src/minimap.js
+++ b/src/minimap.js
@@ -36,6 +36,8 @@ export const useMinimap = () => {
   return useContext(MinimapContext)
 }
 
+const WIDTH = 800
+
 const Minimap = ({
   id,
   tabIndex,
@@ -47,45 +49,25 @@ const Minimap = ({
   scale: scaleProp,
   translate: translateProp,
 }) => {
-  const [projection, setProjection] = useState({
-    value: getProjection(),
-    scale: scaleProp,
-    aspect: aspectProp,
-    translate: translateProp,
-  })
-
-  const WIDTH = 800
+  const [projection, setProjection] = useState(getProjection)
+  const defaults = DEFAULTS[projection.id]
+  const aspect = aspectProp || defaults.aspect
+  const height = WIDTH * aspect
 
   useEffect(() => {
     const updatedProjection = getProjection()
-    const defaults = DEFAULTS[updatedProjection.id]
-    const updatedScale = scaleProp || defaults.scale
-    const updatedAspect = aspectProp || defaults.aspect
-    const updatedTranslate = translateProp || defaults.translate
-
-    updatedProjection.scale(updatedScale * (WIDTH / (2 * Math.PI)))
-    updatedProjection.translate([
-      ((1 + updatedTranslate[0]) * WIDTH) / 2,
-      ((1 + updatedTranslate[1]) * updatedAspect * WIDTH) / 2,
-    ])
-
-    setProjection({
-      scale: updatedScale,
-      aspect: updatedAspect,
-      value: updatedProjection,
-      translate: updatedTranslate,
-    })
-  }, [getProjection, scaleProp, aspectProp, translateProp])
+    setProjection(() => updatedProjection)
+  }, [getProjection])
 
   return (
     <MinimapContext.Provider
       value={{
-        projection: projection.value,
-        translate: projection.translate,
-        scale: projection.scale,
-        aspect: projection.aspect,
+        projection,
+        translate: translateProp || defaults.translate,
+        scale: scaleProp || defaults.scale,
+        aspect,
         width: WIDTH,
-        height: WIDTH * projection.aspect,
+        height,
       }}
     >
       <div
@@ -100,14 +82,14 @@ const Minimap = ({
         }}
       >
         <Regl
-          aspect={projection.aspect}
+          aspect={aspect}
           style={{
             pointerEvents: 'none',
             zIndex: -1,
           }}
         >
           <svg
-            viewBox={`0 0 ${WIDTH} ${WIDTH * projection.aspect}`}
+            viewBox={`0 0 ${WIDTH} ${height}`}
             style={{
               position: 'absolute',
               width: '100%',

--- a/src/path.js
+++ b/src/path.js
@@ -13,6 +13,7 @@ const Path = ({
   opacity = 0.7,
 }) => {
   const [path, setPath] = useState()
+  const [sphere, setSphere] = useState()
   const [data, setData] = useState()
   const { projection } = useMinimap()
   const { ref, transform } = useTransform()
@@ -28,21 +29,27 @@ const Path = ({
   useEffect(() => {
     setPath(geoPath(projection)(data))
   }, [data, projection])
+  useEffect(() => {
+    setSphere(geoPath(projection)({ type: 'Sphere' }))
+  }, [data, projection])
 
   return (
-    path && (
-      <path
-        ref={ref}
-        d={path}
-        stroke={transform ? stroke : 'none'}
-        fill={transform ? fill : 'none'}
-        opacity={opacity}
-        strokeWidth={strokeWidth}
-        transform={transform}
-        style={{
-          vectorEffect: 'non-scaling-stroke',
-        }}
-      />
+    path &&
+    sphere && (
+      <>
+        <path
+          d={path}
+          stroke={transform ? stroke : 'none'}
+          fill={transform ? fill : 'none'}
+          opacity={opacity}
+          strokeWidth={strokeWidth}
+          transform={transform}
+          style={{
+            vectorEffect: 'non-scaling-stroke',
+          }}
+        />
+        <path fill='none' d={sphere} ref={ref} />
+      </>
     )
   )
 }

--- a/src/path.js
+++ b/src/path.js
@@ -13,7 +13,7 @@ const Path = ({
 }) => {
   const [path, setPath] = useState()
   const [data, setData] = useState()
-  const { projection, width, height } = useMinimap()
+  const { projection, scale, translate, width, height } = useMinimap()
 
   useEffect(() => {
     fetch(source)
@@ -27,6 +27,21 @@ const Path = ({
     setPath(geoPath(projection)(data))
   }, [data, projection])
 
+  const actualScale = [
+    (scale * (width / (2 * Math.PI))) / projection.scale(),
+    (scale * (height / Math.PI)) / projection.scale(),
+  ]
+  let actualTranslate = [
+    ((1 + translate[0]) * width) / 2 +
+      ((projection.translate()[0] / projection.scale()) * 2) / width,
+    ((1 + translate[1]) * height) / 2 +
+      ((projection.translate()[1] / projection.scale()) * 2) / height,
+  ]
+  // actualTranslate = [20, 3]
+
+  console.log('projected', projection.scale(), projection.translate())
+  console.log('props', scale, translate)
+  console.log('calculated', actualScale, actualTranslate)
   return (
     <path
       d={path}
@@ -34,6 +49,9 @@ const Path = ({
       fill={fill}
       opacity={opacity}
       strokeWidth={strokeWidth}
+      transform={`scale(${actualScale.join(
+        ' '
+      )}) translate(${actualTranslate.join(' ')})`}
       style={{
         vectorEffect: 'non-scaling-stroke',
       }}

--- a/src/path.js
+++ b/src/path.js
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { geoPath } from 'd3-geo'
 import { feature as topoFeature } from 'topojson-client'
 import { useMinimap } from './minimap'
+import useTransform from './use-transform'
 
 const Path = ({
   source,
@@ -11,18 +12,10 @@ const Path = ({
   strokeWidth = 0.5,
   opacity = 0.7,
 }) => {
-  const ref = useRef(null)
   const [path, setPath] = useState()
-  const [initialized, setInitialized] = useState(false)
   const [data, setData] = useState()
-  const {
-    projection,
-    scale: scaleProp,
-    translate: translateProp,
-    width,
-    height,
-  } = useMinimap()
-  const [transform, setTransform] = useState(null)
+  const { projection } = useMinimap()
+  const { ref, transform } = useTransform()
 
   useEffect(() => {
     fetch(source)
@@ -36,48 +29,13 @@ const Path = ({
     setPath(geoPath(projection)(data))
   }, [data, projection])
 
-  useEffect(() => {
-    const scale = [
-      (scaleProp * (width / (2 * Math.PI))) / projection.scale(),
-      (scaleProp * (height / Math.PI)) / projection.scale(),
-    ]
-
-    const {
-      x,
-      y,
-      width: bWidth,
-      height: bHeight,
-    } = ref.current?.getBBox() ?? {
-      x: 0,
-      y: 0,
-      width,
-      height,
-    }
-
-    const translate = [
-      (scale[0] - 1) * -x +
-        (width - scale[0] * bWidth) / 2 +
-        (translateProp[0] * width) / 2,
-      (scale[1] - 1) * -y +
-        (height - scale[1] * bHeight) / 2 +
-        (translateProp[1] * height) / 2,
-    ]
-
-    setTransform(`translate(${translate.join(' ')}) scale(${scale.join(' ')})`)
-  }, [initialized, projection, scaleProp, translateProp, width, height])
-
-  const pathRef = useCallback((node) => {
-    ref.current = node
-    setInitialized(true)
-  }, [])
-
   return (
     path && (
       <path
-        ref={pathRef}
+        ref={ref}
         d={path}
-        stroke={initialized ? stroke : 'none'}
-        fill={initialized ? fill : 'none'}
+        stroke={transform ? stroke : 'none'}
+        fill={transform ? fill : 'none'}
         opacity={opacity}
         strokeWidth={strokeWidth}
         transform={transform}

--- a/src/path.js
+++ b/src/path.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { geoPath } from 'd3-geo'
 import { feature as topoFeature } from 'topojson-client'
 import { useMinimap } from './minimap'
@@ -13,6 +13,7 @@ const Path = ({
 }) => {
   const ref = useRef(null)
   const [path, setPath] = useState()
+  const [initialized, setInitialized] = useState(false)
   const [data, setData] = useState()
   const {
     projection,
@@ -47,8 +48,6 @@ const Path = ({
       height,
     }
 
-    console.log(parent)
-
     const translate = [
       (parent.width - rect.width) / 2 +
         (2 * (translateProp[0] * width)) / Math.PI,
@@ -57,15 +56,20 @@ const Path = ({
     ]
 
     setTransform(`scale(${scale.join(' ')}) translate(${translate.join(' ')})`)
-  }, [projection, scaleProp, translateProp, width, height])
+  }, [initialized, projection, scaleProp, translateProp, width, height])
+
+  const pathRef = useCallback((node) => {
+    ref.current = node
+    setInitialized(true)
+  }, [])
 
   return (
     path && (
       <path
-        ref={ref}
+        ref={pathRef}
         d={path}
-        stroke={stroke}
-        fill={fill}
+        stroke={initialized ? stroke : 'none'}
+        fill={initialized ? fill : 'none'}
         opacity={opacity}
         strokeWidth={strokeWidth}
         transform={transform}

--- a/src/path.js
+++ b/src/path.js
@@ -42,20 +42,28 @@ const Path = ({
       (scaleProp * (height / Math.PI)) / projection.scale(),
     ]
 
-    const rect = ref.current?.getBoundingClientRect() ?? { width: 0, height: 0 }
-    const parent = ref.current?.parentElement?.getBoundingClientRect() ?? {
+    const {
+      x,
+      y,
+      width: bWidth,
+      height: bHeight,
+    } = ref.current?.getBBox() ?? {
+      x: 0,
+      y: 0,
       width,
       height,
     }
 
     const translate = [
-      (parent.width - rect.width) / 2 +
-        (2 * (translateProp[0] * width)) / Math.PI,
-      (parent.height - rect.height) / 2 +
-        (2 * (translateProp[1] * height)) / Math.PI,
+      (scale[0] - 1) * -x +
+        (width - scale[0] * bWidth) / 2 +
+        (translateProp[0] * width) / 2,
+      (scale[1] - 1) * -y +
+        (height - scale[1] * bHeight) / 2 +
+        (translateProp[1] * height) / 2,
     ]
 
-    setTransform(`scale(${scale.join(' ')}) translate(${translate.join(' ')})`)
+    setTransform(`translate(${translate.join(' ')}) scale(${scale.join(' ')})`)
   }, [initialized, projection, scaleProp, translateProp, width, height])
 
   const pathRef = useCallback((node) => {

--- a/src/sphere.js
+++ b/src/sphere.js
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react'
 import { geoPath } from 'd3-geo'
 import { useMinimap } from './minimap'
+import useTransform from './use-transform'
 
 const Sphere = ({ fill, stroke, strokeWidth = 0.5, opacity = 0.2 }) => {
+  const { transform, ref } = useTransform()
   const { projection, width, height } = useMinimap()
   const [path, setPath] = useState()
   // replace with uui
@@ -19,7 +21,13 @@ const Sphere = ({ fill, stroke, strokeWidth = 0.5, opacity = 0.2 }) => {
     >
       <mask id={id}>
         <rect x='0' y='0' width='100%' height='100%' fill='#FFFFFF' />
-        <path fill='#000000' id='circle-cutout' d={path} />
+        <path
+          fill={transform ? '#000000' : 'none'}
+          id='circle-cutout'
+          d={path}
+          ref={ref}
+          transform={transform}
+        />
       </mask>
       <rect
         x='0'
@@ -27,18 +35,19 @@ const Sphere = ({ fill, stroke, strokeWidth = 0.5, opacity = 0.2 }) => {
         width='100%'
         height='100%'
         mask={`url(#${id})`}
-        style={{ fill: fill }}
+        style={{ fill: transform ? fill : 'none' }}
       />
       {stroke && (
         <path
           fill='none'
-          stroke={stroke}
+          stroke={transform ? stroke : 'none'}
           strokeWidth={strokeWidth}
           opacity={opacity}
           style={{
             vectorEffect: 'non-scaling-stroke',
           }}
           d={path}
+          transform={transform}
         />
       )}
     </svg>

--- a/src/use-transform.js
+++ b/src/use-transform.js
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMinimap } from './minimap'
+
+const useTransform = () => {
+  const ref = useRef(null)
+  const [initialized, setInitialized] = useState(false)
+  const {
+    projection,
+    scale: scaleProp,
+    translate: translateProp,
+    width,
+    height,
+  } = useMinimap()
+  const [transform, setTransform] = useState(null)
+
+  const getBBox = useMemo(
+    () => () => {
+      const {
+        x,
+        y,
+        width: bWidth,
+        height: bHeight,
+      } = ref.current?.getBBox() ?? {}
+
+      const hasValues = !!(bWidth || bHeight)
+      if (!initialized && hasValues) {
+        setInitialized(true)
+      } else if (initialized && !hasValues) {
+        setInitialized(false)
+      }
+
+      return {
+        x,
+        y,
+        width: bWidth,
+        height: bHeight,
+      }
+    },
+    [initialized]
+  )
+
+  useEffect(() => {
+    const scale = [
+      (scaleProp * (width / (2 * Math.PI))) / projection.scale(),
+      (scaleProp * (height / Math.PI)) / projection.scale(),
+    ]
+
+    const { x, y, width: bWidth, height: bHeight } = getBBox()
+
+    const translate = [
+      (scale[0] - 1) * -x +
+        (width - scale[0] * bWidth) / 2 +
+        (translateProp[0] * width) / 2,
+      (scale[1] - 1) * -y +
+        (height - scale[1] * bHeight) / 2 +
+        (translateProp[1] * height) / 2,
+    ]
+
+    setTransform(`translate(${translate.join(' ')}) scale(${scale.join(' ')})`)
+  }, [getBBox, projection, scaleProp, translateProp, width, height])
+
+  const componentRef = useCallback((node) => {
+    ref.current = node
+    setInitialized(true)
+  }, [])
+
+  return { transform: initialized ? transform : null, ref: componentRef }
+}
+
+export default useTransform

--- a/src/use-transform.js
+++ b/src/use-transform.js
@@ -10,6 +10,7 @@ const useTransform = () => {
     translate: translateProp,
     width,
     height,
+    aspect,
   } = useMinimap()
   const [transform, setTransform] = useState(null)
 
@@ -42,7 +43,8 @@ const useTransform = () => {
   useEffect(() => {
     const scale = [
       (scaleProp * (width / (2 * Math.PI))) / projection.scale(),
-      (scaleProp * (height / Math.PI)) / projection.scale(),
+      (scaleProp * ((height * (3 / 2 - aspect)) / Math.PI)) /
+        projection.scale(),
     ]
 
     const { x, y, width: bWidth, height: bHeight } = getBBox()
@@ -57,7 +59,7 @@ const useTransform = () => {
     ]
 
     setTransform(`translate(${translate.join(' ')}) scale(${scale.join(' ')})`)
-  }, [getBBox, projection, scaleProp, translateProp, width, height])
+  }, [getBBox, projection, scaleProp, translateProp, width, height, aspect])
 
   const componentRef = useCallback((node) => {
     ref.current = node

--- a/src/use-transform.js
+++ b/src/use-transform.js
@@ -52,10 +52,12 @@ const useTransform = () => {
     const translate = [
       (scale[0] - 1) * -x +
         (width - scale[0] * bWidth) / 2 +
-        (translateProp[0] * width) / 2,
+        (translateProp[0] * width) / 2 -
+        x,
       (scale[1] - 1) * -y +
         (height - scale[1] * bHeight) / 2 +
-        (translateProp[1] * height) / 2,
+        (translateProp[1] * height) / 2 -
+        y,
     ]
 
     setTransform(`translate(${translate.join(' ')}) scale(${scale.join(' ')})`)


### PR DESCRIPTION
Avoid passing `translate` and `scale` props around via operations on `projection` and instead use to transform SVG elements.

- [x] TODO: handle `Sphere`
- [x] TODO: handle `Graticule`
- [x] TODO: fix `translate()` calculation

Before:
![CleanShot 2023-03-01 at 15 25 37](https://user-images.githubusercontent.com/12436887/222289901-6993681a-b24a-4b44-a4f2-012ce850a98d.gif)

After:
![CleanShot 2023-03-01 at 15 23 43](https://user-images.githubusercontent.com/12436887/222289685-898d0fd4-82b8-47b5-b96d-e0c5eb7f4f1c.gif)