### PR TITLE
points

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "d3-geo": "^2.0.1",
-        "glsl-geo-projection": "^1.0.1",
+        "glsl-geo-projection": "^1.1.0",
         "regl": "^2.1.0",
         "topojson-client": "^3.1.0",
         "zarr-js": "^2.1.3"
@@ -3001,9 +3001,9 @@
       "dev": true
     },
     "node_modules/glsl-geo-projection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.0.1.tgz",
-      "integrity": "sha512-6r118GFi+q5lzF3N0Jevv15eveVwLeIqqFe4XRnnYnU/Y/Bp38XpySQaGBO0EzXNhzesUik7c2uSEuYUwa+ogw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.1.0.tgz",
+      "integrity": "sha512-nLDpPFnNI6jmEx6JYW+XqeBzCZ4vYbaKZiYbeZmhvTsbsxFRTvVBdZgk9b4rt5o/FL/vj16SgRw4olF6109tCA=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
@@ -8051,9 +8051,9 @@
       "dev": true
     },
     "glsl-geo-projection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.0.1.tgz",
-      "integrity": "sha512-6r118GFi+q5lzF3N0Jevv15eveVwLeIqqFe4XRnnYnU/Y/Bp38XpySQaGBO0EzXNhzesUik7c2uSEuYUwa+ogw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.1.0.tgz",
+      "integrity": "sha512-nLDpPFnNI6jmEx6JYW+XqeBzCZ4vYbaKZiYbeZmhvTsbsxFRTvVBdZgk9b4rt5o/FL/vj16SgRw4olF6109tCA=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@carbonplan/prettier",
   "dependencies": {
     "d3-geo": "^2.0.1",
-    "glsl-geo-projection": "^1.0.1",
+    "glsl-geo-projection": "^1.1.0",
     "regl": "^2.1.0",
     "topojson-client": "^3.1.0",
     "zarr-js": "^2.1.3"

--- a/projections/package.json
+++ b/projections/package.json
@@ -6,6 +6,6 @@
   "source": "src/index.js",
   "dependencies": {
     "d3-geo": "^2.0.1",
-    "glsl-geo-projection": "^1.0.1"
+    "glsl-geo-projection": "^1.1.0"
   }
 }

--- a/projections/src/equirectangular.js
+++ b/projections/src/equirectangular.js
@@ -7,7 +7,7 @@ export default function () {
     name: 'equirectangularInvert',
     func: equirectangularInvert,
     nameForward: 'equirectangular',
-    funcForward: equirectangular
+    funcForward: equirectangular,
   }
   projection.id = 'equirectangular'
   return projection

--- a/projections/src/equirectangular.js
+++ b/projections/src/equirectangular.js
@@ -1,11 +1,13 @@
 import { geoEquirectangular } from 'd3-geo'
-import { equirectangularInvert } from 'glsl-geo-projection'
+import { equirectangularInvert, equirectangular } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoEquirectangular().precision(0.1)
   projection.glsl = {
-    func: equirectangularInvert,
     name: 'equirectangularInvert',
+    func: equirectangularInvert,
+    nameForward: 'equirectangular',
+    funcForward: equirectangular
   }
   projection.id = 'equirectangular'
   return projection

--- a/projections/src/mercator.js
+++ b/projections/src/mercator.js
@@ -1,9 +1,14 @@
 import { geoMercator } from 'd3-geo'
-import { mercatorInvert } from 'glsl-geo-projection'
+import { mercatorInvert, mercator } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoMercator().precision(0.1)
-  projection.glsl = { func: mercatorInvert, name: 'mercatorInvert' }
+  projection.glsl = { 
+    name: 'mercatorInvert',
+    func: mercatorInvert, 
+    nameForward: 'mercator',
+    funcForward: mercator
+  }
   projection.id = 'mercator'
   return projection
 }

--- a/projections/src/mercator.js
+++ b/projections/src/mercator.js
@@ -3,11 +3,11 @@ import { mercatorInvert, mercator } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoMercator().precision(0.1)
-  projection.glsl = { 
+  projection.glsl = {
     name: 'mercatorInvert',
-    func: mercatorInvert, 
+    func: mercatorInvert,
     nameForward: 'mercator',
-    funcForward: mercator
+    funcForward: mercator,
   }
   projection.id = 'mercator'
   return projection

--- a/projections/src/naturalEarth1.js
+++ b/projections/src/naturalEarth1.js
@@ -3,11 +3,11 @@ import { naturalEarth1, naturalEarth1Invert } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoNaturalEarth1().precision(0.1)
-  projection.glsl = { 
+  projection.glsl = {
     name: 'naturalEarth1Invert',
-    func: naturalEarth1Invert, 
+    func: naturalEarth1Invert,
     nameForward: 'naturalEarth1',
-    funcForward: naturalEarth1,  
+    funcForward: naturalEarth1,
   }
   projection.id = 'naturalEarth1'
   return projection

--- a/projections/src/naturalEarth1.js
+++ b/projections/src/naturalEarth1.js
@@ -1,9 +1,14 @@
 import { geoNaturalEarth1 } from 'd3-geo'
-import { naturalEarth1Invert } from 'glsl-geo-projection'
+import { naturalEarth1, naturalEarth1Invert } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoNaturalEarth1().precision(0.1)
-  projection.glsl = { func: naturalEarth1Invert, name: 'naturalEarth1Invert' }
+  projection.glsl = { 
+    name: 'naturalEarth1Invert',
+    func: naturalEarth1Invert, 
+    nameForward: 'naturalEarth1',
+    funcForward: naturalEarth1,  
+  }
   projection.id = 'naturalEarth1'
   return projection
 }

--- a/projections/src/orthographic.js
+++ b/projections/src/orthographic.js
@@ -3,11 +3,11 @@ import { orthographicInvert, orthographic } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoOrthographic().precision(0.1)
-  projection.glsl = { 
+  projection.glsl = {
     name: 'orthographicInvert',
-    func: orthographicInvert, 
+    func: orthographicInvert,
     nameForward: 'orthographic',
-    funcForward: orthographic
+    funcForward: orthographic,
   }
   projection.id = 'orthographic'
   return projection

--- a/projections/src/orthographic.js
+++ b/projections/src/orthographic.js
@@ -1,9 +1,14 @@
 import { geoOrthographic } from 'd3-geo'
-import { orthographicInvert } from 'glsl-geo-projection'
+import { orthographicInvert, orthographic } from 'glsl-geo-projection'
 
 export default function () {
   const projection = geoOrthographic().precision(0.1)
-  projection.glsl = { func: orthographicInvert, name: 'orthographicInvert' }
+  projection.glsl = { 
+    name: 'orthographicInvert',
+    func: orthographicInvert, 
+    nameForward: 'orthographic',
+    funcForward: orthographic
+  }
   projection.id = 'orthographic'
   return projection
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export { default as Minimap, useMinimap } from './minimap'
 export { default as Raster } from './raster'
+export { default as Points } from './points'
 export { default as Sphere } from './sphere'
 export { default as Path } from './path'
 export { default as Graticule } from './graticule'

--- a/src/points.js
+++ b/src/points.js
@@ -1,0 +1,194 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { useRegl } from './regl'
+import { useMinimap } from './minimap'
+
+const Points = ({
+  position,
+  value,
+  pointSize = 5,
+  opacity = 1,
+  colormap = null,
+  clim = null,
+  mode = 'lut'
+}) => {
+  const { viewport, regl } = useRegl()
+  const { scale, translate, projection } = useMinimap()
+
+  const redraw = useRef()
+  const draw = useRef()
+  const context = useRef({})
+  const lut = useRef()
+  const invalidated = useRef(null)
+
+  if (mode == 'lut' && !colormap) {
+    throw new Error("must provide 'colormap' when using 'lut' mode")
+  }
+
+  if (mode == 'lut' && !clim) {
+    throw new Error("must provide 'clim' when using 'lut' mode")
+  }
+
+  useEffect(() => {
+    regl.frame((_context) => {
+      context.current = _context
+
+      if (invalidated.current) {
+        regl.clear({
+          color: [0, 0, 0, 0],
+          depth: 1,
+        })
+
+        redraw.current(invalidated.current)
+      }
+      invalidated.current = null
+    })
+  }, [])
+
+  useEffect(() => {
+    lut.current ||= regl.texture()
+
+    let uniforms = {
+      pixelRatio: regl.prop('pixelRatio'),
+      viewportWidth: regl.prop('viewportWidth'),
+      viewportHeight: regl.prop('viewportHeight'),
+      bounds: regl.prop('bounds'),
+      scale: regl.prop('scale'),
+      translate: regl.prop('translate'),
+      pointSize: regl.prop('pointSize'),
+      opacity: regl.prop('opacity')
+    }
+
+     if (mode === 'lut') {
+        uniforms = {
+          ...uniforms,
+          lut: regl.prop('lut'),
+          clim: regl.prop('clim'),
+        }
+      }
+
+    draw.current = regl({
+      vert: `
+      #ifdef GL_FRAGMENT_PRECISION_HIGH
+      precision highp float;
+      #else
+      precision mediump float;
+      #endif
+      attribute vec2 position;
+      attribute float value;
+      uniform float scale;
+      uniform vec2 translate;
+      uniform float pointSize;
+      const float pi = 3.14159265358979323846264;
+      const float halfPi = pi * 0.5;
+      varying float valuev;
+
+      ${projection.glsl.funcForward}
+      void main() {
+        valuev = value;
+        vec2 location = ${projection.glsl.nameForward}(position.x, position.y);
+        gl_PointSize = pointSize;
+        gl_Position = vec4(location.x * scale / (halfPi * 2.0) + translate.x, location.y * scale / halfPi - translate.y, 0.0, 1.0);
+      }
+      `,
+
+      frag: `
+      #ifdef GL_FRAGMENT_PRECISION_HIGH
+      precision highp float;
+      #else
+      precision mediump float;
+      #endif
+      uniform vec2 clim;
+      uniform sampler2D lut;
+      uniform float opacity;
+      varying float valuev;
+      
+      void main() {
+        if (length(gl_PointCoord.xy - 0.5) > 0.5) {
+          discard;
+        }
+
+        float rescaled = (valuev - clim.x)/(clim.y - clim.x);
+        vec4 c = texture2D(lut, vec2(rescaled, 1.0));
+        gl_FragColor = vec4(c.x, c.y, c.z, 1.0) * opacity;
+      }
+      `,
+
+      attributes: {
+        position: regl.prop('position'),
+        value: regl.prop('value'),
+      },
+
+      uniforms: uniforms,
+
+      count: position.length,
+
+      primitive: 'points',
+
+      depth: { enable: false },
+
+      blend: {
+        enable: true,
+        func: {
+          srcRGB: 'one',
+          srcAlpha: 'one',
+          dstRGB: 'one minus src alpha',
+          dstAlpha: 'one minus src alpha',
+        },
+      },
+    })
+  }, [projection.glsl.name])
+
+  redraw.current = (invalidatedBy) => {
+    if (draw.current) {
+      const { pixelRatio } = context.current
+      draw.current({
+        bounds: [-90, 90, -180, 180],
+        lut: lut.current,
+        position,
+        value,
+        scale,
+        clim,
+        translate,
+        pointSize,
+        opacity,
+        viewportWidth: viewport.width * pixelRatio,
+        viewportHeight: viewport.height * pixelRatio,
+        pixelRatio,
+      })
+    }
+  }
+
+  useEffect(() => {
+    invalidated.current = 'on viewport change'
+  }, [viewport])
+
+  useEffect(() => {
+    if (colormap) {
+      lut.current({
+        data: colormap,
+        format: 'rgb',
+        shape: [colormap.length, 1],
+      })
+      invalidated.current = 'on colormap change'
+    }
+  }, [colormap])
+
+  useEffect(() => {
+    invalidated.current = 'on prop change'
+  }, [
+    position,
+    value,
+    projection,
+    scale,
+    pointSize,
+    opacity,
+    clim && clim[0],
+    clim && clim[1],
+    translate[0],
+    translate[1],
+  ])
+
+  return null
+}
+
+export default Points

--- a/src/points.js
+++ b/src/points.js
@@ -5,7 +5,7 @@ import { useMinimap } from './minimap'
 const Points = ({
   position,
   value,
-  pointSize = 5,
+  size = 5,
   opacity = 1,
   colormap = null,
   clim = null,
@@ -54,7 +54,7 @@ const Points = ({
       bounds: regl.prop('bounds'),
       scale: regl.prop('scale'),
       translate: regl.prop('translate'),
-      pointSize: regl.prop('pointSize'),
+      size: regl.prop('size'),
       opacity: regl.prop('opacity'),
     }
 
@@ -77,7 +77,7 @@ const Points = ({
       attribute float value;
       uniform float scale;
       uniform vec2 translate;
-      uniform float pointSize;
+      uniform float size;
       const float pi = 3.14159265358979323846264;
       const float halfPi = pi * 0.5;
       varying float valuev;
@@ -86,7 +86,7 @@ const Points = ({
       void main() {
         valuev = value;
         vec2 location = ${projection.glsl.nameForward}(position.x, position.y);
-        gl_PointSize = pointSize;
+        gl_PointSize = size;
         gl_Position = vec4(location.x * scale / (halfPi * 2.0) + translate.x, location.y * scale / halfPi - translate.y, 0.0, 1.0);
       }
       `,
@@ -149,7 +149,7 @@ const Points = ({
         scale,
         clim,
         translate,
-        pointSize,
+        size,
         opacity,
         viewportWidth: viewport.width * pixelRatio,
         viewportHeight: viewport.height * pixelRatio,
@@ -180,7 +180,7 @@ const Points = ({
     value,
     projection,
     scale,
-    pointSize,
+    size,
     opacity,
     clim && clim[0],
     clim && clim[1],

--- a/src/points.js
+++ b/src/points.js
@@ -9,7 +9,7 @@ const Points = ({
   opacity = 1,
   colormap = null,
   clim = null,
-  mode = 'lut'
+  mode = 'lut',
 }) => {
   const { viewport, regl } = useRegl()
   const { scale, translate, projection } = useMinimap()
@@ -55,16 +55,16 @@ const Points = ({
       scale: regl.prop('scale'),
       translate: regl.prop('translate'),
       pointSize: regl.prop('pointSize'),
-      opacity: regl.prop('opacity')
+      opacity: regl.prop('opacity'),
     }
 
-     if (mode === 'lut') {
-        uniforms = {
-          ...uniforms,
-          lut: regl.prop('lut'),
-          clim: regl.prop('clim'),
-        }
+    if (mode === 'lut') {
+      uniforms = {
+        ...uniforms,
+        lut: regl.prop('lut'),
+        clim: regl.prop('clim'),
       }
+    }
 
     draw.current = regl({
       vert: `

--- a/src/regl.js
+++ b/src/regl.js
@@ -1,6 +1,5 @@
 import React, {
   createContext,
-  useCallback,
   useState,
   useEffect,
   useContext,


### PR DESCRIPTION
Adds a new `<Points/>` component type which renders points on the map using WebGL, so it supports a potentially very large number, albeit with some limits on rendering options. Along with providing an array for `position` (of lon, lat pairs) and `value` with values to be mapped to color via a `colormap`, supports specifying a `size` and `opacity`.

Required exposing the forward glsl projections on the underlying projection objects.