### PR TITLE
Render error boundary within `Minimap`

### DIFF
--- a/src/error-boundary.js
+++ b/src/error-boundary.js
@@ -1,14 +1,18 @@
 import React from 'react'
 
+// Based on https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+const DEFAULT_ERROR = 'Your device doesn’t support rendering this map.'
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { errorMessage: null }
   }
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true }
+    return {
+      errorMessage: error.message ?? defaultError,
+    }
   }
 
   componentDidCatch(error, info) {
@@ -21,11 +25,11 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
-    if (this.state.hasError) {
+    if (this.state.errorMessage) {
       // You can render any custom fallback UI
       return (
         <div style={{ textAlign: 'center', padding: 24 }}>
-          Your device doesn't support rendering this map.
+          {this.props.showErrorTrace ? this.state.errorMessage : DEFAULT_ERROR}
         </div>
       )
     }

--- a/src/error-boundary.js
+++ b/src/error-boundary.js
@@ -1,0 +1,37 @@
+import React from 'react'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, info) {
+    // Example "componentStack":
+    //   in ComponentThatThrows (created by App)
+    //   in ErrorBoundary (created by App)
+    //   in div (created by App)
+    //   in App
+    console.error(error, info.componentStack)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <div style={{ textAlign: 'center', padding: 24 }}>
+          Your device doesn't support rendering this map.
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/minimap.js
+++ b/src/minimap.js
@@ -41,6 +41,7 @@ const Minimap = ({
   aspect: aspectProp,
   scale: scaleProp,
   translate: translateProp,
+  showErrorTrace = false,
 }) => {
   const [projection, setProjection] = useState({
     value: getProjection(),
@@ -94,7 +95,7 @@ const Minimap = ({
           ...style,
         }}
       >
-        <ErrorBoundary>
+        <ErrorBoundary showErrorTrace={showErrorTrace}>
           <Regl
             aspect={projection.aspect}
             style={{

--- a/src/minimap.js
+++ b/src/minimap.js
@@ -1,11 +1,6 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  createContext,
-  useContext,
-} from 'react'
+import React, { useState, useEffect, createContext, useContext } from 'react'
 import Regl from './regl'
+import ErrorBoundary from './error-boundary'
 
 const DEFAULTS = {
   naturalEarth1: {
@@ -99,27 +94,29 @@ const Minimap = ({
           ...style,
         }}
       >
-        <Regl
-          aspect={projection.aspect}
-          style={{
-            pointerEvents: 'none',
-            zIndex: -1,
-          }}
-        >
-          <svg
-            viewBox={`0 0 ${WIDTH} ${WIDTH * projection.aspect}`}
+        <ErrorBoundary>
+          <Regl
+            aspect={projection.aspect}
             style={{
-              position: 'absolute',
-              width: '100%',
-              top: 0,
-              left: 0,
-              overflow: 'hidden',
               pointerEvents: 'none',
+              zIndex: -1,
             }}
           >
-            {children}
-          </svg>
-        </Regl>
+            <svg
+              viewBox={`0 0 ${WIDTH} ${WIDTH * projection.aspect}`}
+              style={{
+                position: 'absolute',
+                width: '100%',
+                top: 0,
+                left: 0,
+                overflow: 'hidden',
+                pointerEvents: 'none',
+              }}
+            >
+              {children}
+            </svg>
+          </Regl>
+        </ErrorBoundary>
       </div>
     </MinimapContext.Provider>
   )


### PR DESCRIPTION
More general alternative to https://github.com/carbonplan/minimaps/pull/34

As currently implemented, this approach suppresses _all errors_ by default, which is not appropriate in all situations, especially development. I could imagine inverting the `showErrorTrace` to show the error trace in all cases unless a specific override is provided.