### PR TITLE
fix rendering on mobile GPUs that can't handle large floats

### DIFF
--- a/src/raster.js
+++ b/src/raster.js
@@ -43,12 +43,22 @@ const needsNormalization = (nullValue, clim) => {
   return largeNullValue || largeClim
 }
 
+const normalizeBuffer = { current: null }
+
 const normalizeDataForTexture = (data, nullValue, scale) => {
   if (!data?.data || !ArrayBuffer.isView(data.data)) {
     return data
   }
 
-  const normalized = new Float32Array(data.data.length)
+  // Reuse buffer if same size for performance
+  if (
+    !normalizeBuffer.current ||
+    normalizeBuffer.current.length !== data.data.length
+  ) {
+    normalizeBuffer.current = new Float32Array(data.data.length)
+  }
+  const normalized = normalizeBuffer.current
+
   for (let i = 0; i < data.data.length; i++) {
     const v = data.data[i]
     if (v === nullValue || Number.isNaN(v)) {

--- a/src/raster.js
+++ b/src/raster.js
@@ -37,13 +37,10 @@ const FILL_SENTINEL = -3.4e4
 const HALF_FLOAT_MAX = 65504
 
 const needsNormalization = (nullValue, clim) => {
-  if (Math.abs(nullValue) > HALF_FLOAT_MAX) {
-    return true
-  }
-  if (clim && (Math.abs(clim[0]) > HALF_FLOAT_MAX || Math.abs(clim[1]) > HALF_FLOAT_MAX)) {
-    return true
-  }
-  return false
+  const largeNullValue = Math.abs(nullValue) > HALF_FLOAT_MAX
+  const largeClim =
+    clim && Math.max(Math.abs(clim[0]), Math.abs(clim[1])) > HALF_FLOAT_MAX
+  return largeNullValue || largeClim
 }
 
 const normalizeDataForTexture = (data, nullValue, scale) => {

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -34,6 +34,7 @@ export const frag = (customFrag, projection, mode, transpose) => {
       uniform bool transpose;
       uniform float nullValue;
       uniform float aspect;
+      uniform float dataScale;
       ${mode === 'lut' ? 'uniform sampler2D lut;' : ''}
       ${mode === 'lut' ? 'uniform vec3 nullColor;' : ''}
 
@@ -86,7 +87,7 @@ export const frag = (customFrag, projection, mode, transpose) => {
           gl_FragColor = vec4(c.x, c.y, c.z, 1.0);
           `
   } else if (mode === 'rgb') {
-    inner = 'gl_FragColor = vec4(value.x , value.y, value.z, 1.0);'
+    inner = 'gl_FragColor = vec4(value.x, value.y, value.z, 1.0);'
   }
 
   return `
@@ -147,6 +148,7 @@ export const frag = (customFrag, projection, mode, transpose) => {
         if ((!inboundsY || !inboundsX) || (value.x == nullValue || isnan(value.x))) {
           gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
         } else {
+          value = value * dataScale;
           ${inner}
         }
       }


### PR DESCRIPTION
This checks if data exceeds half float precision and if so normalizes the data on the CPU and then unwinds that on the GPU. My more explicate GPU checks weren't reliable on all browsers i tried so we're just doing anything that is big (including any thing that uses our evil e36 fill). Performance doesn't seem noticeable in my testing and I think worth the big visual improvements on my phone (same as tyler's) in both chrome and FF!  Also added a little caching so we don't trigger refetches on clim change.

Going forward we should try not to use that massive fill value where possible so we can dodge this code path. 